### PR TITLE
Updates to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @coinbase/cbpay-js
 
-This repository houses the source code for the Coinbase Pay Javascript SDK.
+This repository houses the source code for the Coinbase Pay JavaScript SDK.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@coinbase/pay",
+  "name": "@coinbase/cbpay-js",
   "version": "0.0.1",
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "dist/index.js",
@@ -10,7 +10,8 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsup",
@@ -21,7 +22,6 @@
     "clean": "rimraf lib cjs *.tsbuildinfo cbpay-sdk*",
     "prepare": "yarn run build",
     "typecheck": "tsc --noEmit",
-    "build-and-zip": "yarn build && mkdir -p cbpay-sdk && cp package.json cbpay-sdk/package.json && cp -r dist cbpay-sdk/dist && tar -czf cbpay-sdk.tgz cbpay-sdk && rm -rf cbpay-sdk",
     "check-ci": "yarn run typecheck && yarn run lint && yarn run test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@coinbase/cbpay-js",
   "version": "0.0.1",
-  "license": "SEE LICENSE IN LICENSE.md",
+  "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR cleans up `package.json` a bit:

- Uses `name` that we plan to release under.
- Updates `license` field to use SPDX identifier.
- Remove zip script.

Note: License change and removal of resolutions will happen in follow-up PRs.