### PR TITLE
Remove yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,5 @@
     "ts-jest": "^27.1.3",
     "tsup": "^5.11.13",
     "typescript": "^4.4.4"
-  },
-  "resolutions": {
-    "ansi-regex": "^5.0.1",
-    "minimist": "^1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,7 +833,12 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^4.1.0, ansi-regex@^5.0.1:
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
+ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
 
@@ -2446,7 +2451,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
This PR removes the yarn resolutions. For reference, we can use Jordan's internal guide for resolving CVEs from salus/yarn audit.