### PR TITLE
Add additional supported networks

### DIFF
--- a/src/types/onramp.ts
+++ b/src/types/onramp.ts
@@ -1,4 +1,25 @@
-export type SupportedBlockchains = 'ethereum' | 'avalanche-c-chain' | 'solana';
+export type SupportedBlockchains =
+  | 'algorand'
+  | 'avalanche-c-chain'
+  | 'bitcoin'
+  | 'bitcoin-cash'
+  | 'cardano'
+  | 'celo'
+  | 'cosmos'
+  | 'dash'
+  | 'dfinity'
+  | 'dogecoin'
+  | 'eos'
+  | 'ethereum'
+  | 'ethereum-classic'
+  | 'filecoin'
+  | 'horizen'
+  | 'litecoin'
+  | 'polkadot'
+  | 'solana'
+  | 'stellar'
+  | 'tezos'
+  | 'zcash';
 
 export type DestinationWallet = {
   address: string;


### PR DESCRIPTION
### Motivation
Extending the supported blockchain networks. New networks include:
- algorand
- bitcoin
- bitcoin-cash
- cardano
- celo
- cosmos
- dash
- dfinity
- dogecoin
- eos
- ethereum-classic
- filecoin
- horizen
- litecoin
- polkadot
- stellar
- tezos
- zcash
