### PR TITLE
fix: build produces invalid CJS output

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,10 +2,10 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/utils/postMessage.ts'],
-  splitting: true,
+  splitting: false,
   sourcemap: true,
   clean: true,
   dts: true,
   format: ['cjs', 'esm'],
-  target: 'es5',
+  target: ['chrome64', 'firefox62', 'safari11.1', 'edge79'],
 });


### PR DESCRIPTION
When the output is set to es5, tsup includes an invalid import statement in the CJS output.

Fixes #27 .

### Motivation
The current build causes errors when using Jest to test code that imports this module, even when using a browser test environment.

### Solution
Change the build target to not use `es5`. There appears to be an issue with how `tsup` transpiles code to es5.

### Open questions
Are the browser versions specified as the build target appropriate?