### PR TITLE
Add preset amount parameters

### DIFF
--- a/src/onramp/initOnRamp.test.ts
+++ b/src/onramp/initOnRamp.test.ts
@@ -7,7 +7,7 @@ describe('initOnRamp', () => {
       experienceLoggedIn: 'popup',
       experienceLoggedOut: 'popup',
       appId: 'abc123',
-      widgetParameters: { destinationWallets: [], amount: { value: 0, currencySymbol: 'ETH' } },
+      widgetParameters: { destinationWallets: [] },
     });
 
     expect(instance instanceof CBPayInstance).toBe(true);

--- a/src/onramp/initOnRamp.ts
+++ b/src/onramp/initOnRamp.ts
@@ -2,16 +2,17 @@ import { CBPayExperienceOptions } from '../types/widget';
 import { CBPayInstance, CBPayInstanceType } from '../utils/CBPayInstance';
 import { DestinationWallet } from '../types/onramp';
 
-type Amount = {
-  /** fiat currency code (e.g. USD, EUR) */
-  currencySymbol: string;
-  value: number;
-};
-
 type OnRampAppParams = {
+  /** The destination wallets supported by your application (BTC, ETH, etc). */
   destinationWallets: DestinationWallet[];
-  // TODO: add support for amount
-  amount?: Amount;
+  /** The preset input amount as a crypto value. i.e. 0.1 ETH. This will be the initial default for all cryptocurrencies. */
+  presetCryptoAmount?: number;
+  /**
+   * The preset input amount as a fiat value. i.e. 15 USD.
+   * This will be the initial default for all cryptocurrencies. Ignored if presetCryptoAmount is also set.
+   * Also note this only works for a subset of fiat currencies: USD, CAD, GBP, EUR
+   * */
+  presetFiatAmount?: number;
 };
 
 type InitOnRampParams = CBPayExperienceOptions<OnRampAppParams>;


### PR DESCRIPTION

### Motivation
Adding preset amount parameters as options to the widget.
- `presetCryptoAmount` defaults to input type "crypto" and the amount for the selected asset.
- `presetFiatAmount` defaults the input type to fiat and the amount for the selected asset (will only work for USD, CAD, GBP, EUR for now)
