### PR TITLE
Check for null contentWindow

### DIFF
--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -198,8 +198,8 @@ export class CoinbasePixel {
   private sendAppParams = (appParams: JsonObject, callback?: () => void): void => {
     if (this.nonce) {
       callback?.();
-    } else if (this.pixelIframe) {
-      broadcastPostMessage(this.pixelIframe.contentWindow as Window, 'app_params', {
+    } else if (this.pixelIframe && this.pixelIframe.contentWindow) {
+      broadcastPostMessage(this.pixelIframe.contentWindow, 'app_params', {
         data: appParams,
       });
       this.onMessage('on_app_params_nonce', {


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

When implementing cb-pay using React, I encountered an error: `Unhandled Rejection (TypeError): Cannot read properties of null (reading 'postMessage')`. On investigating, I think the `pixelIframe` still hasn't loaded at the time that `sendAppParams` so its `contentWindow` is still null.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Add a check to ensure the `contentWindow` is not null before calling `broadcastPostMessage`.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->

I didn't see any change in the behavior despite just doing nothing in this case, presumably because the `pixel_ready` listener also calls `sendAppParams` here?
https://github.com/coinbase/cbpay-js/blob/a2fdbb77efd9653e833a9e0a0af0ac3252b5933d/src/utils/CoinbasePixel.ts#L159-L165