### PR TITLE
Update pixel logic & tests to improve loading state management

### DIFF
--- a/src/onramp/initOnRamp.ts
+++ b/src/onramp/initOnRamp.ts
@@ -1,6 +1,7 @@
 import { CBPayExperienceOptions } from '../types/widget';
 import { CBPayInstance, CBPayInstanceType } from '../utils/CBPayInstance';
 import { OnRampAppParams } from '../types/onramp';
+import { generateOnRampURL } from './generateOnRampURL';
 
 export type InitOnRampParams = CBPayExperienceOptions<OnRampAppParams>;
 
@@ -14,6 +15,13 @@ export const initOnRamp = ({
     widget: 'buy',
     experienceLoggedIn,
     appParams: widgetParameters,
+    onFallbackOpen: () => {
+      const url = generateOnRampURL({
+        ...options,
+        ...widgetParameters,
+      });
+      window.open(url);
+    },
   });
   return instance;
 };

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -19,7 +19,8 @@ export type CBPayExperienceOptions<T> = {
   target?: string;
   appId: string;
   host?: string;
-  onReady?: () => void;
+  debug?: boolean;
+  onReady?: (error?: Error) => void;
   onExit?: (error?: Error) => void;
   onSuccess?: () => void;
   onEvent?: (event: EventMetadata) => void;

--- a/src/utils/CBPayInstance.ts
+++ b/src/utils/CBPayInstance.ts
@@ -1,6 +1,6 @@
 import { JsonObject } from 'types/JsonTypes';
 import { CBPayExperienceOptions, Experience, WidgetType } from 'types/widget';
-import { CoinbasePixel } from './CoinbasePixel';
+import { CoinbasePixel, CoinbasePixelConstructorParams } from './CoinbasePixel';
 
 export type InternalExperienceOptions = Omit<
   CBPayExperienceOptions<JsonObject>,
@@ -12,7 +12,8 @@ export type InternalExperienceOptions = Omit<
 
 export type CBPayInstanceConstructorArguments = {
   appParams: JsonObject;
-} & InternalExperienceOptions;
+} & InternalExperienceOptions &
+  Pick<CoinbasePixelConstructorParams, 'onFallbackOpen'>;
 
 const widgetRoutes: Record<WidgetType, string> = {
   buy: '/buy',
@@ -29,17 +30,13 @@ export class CBPayInstance implements CBPayInstanceType {
   private options: InternalExperienceOptions;
 
   constructor(options: CBPayInstanceConstructorArguments) {
-    const appParams = {
-      widget: options.widget,
-      ...options.appParams,
-    };
-
     this.options = options;
     this.pixel = new CoinbasePixel({
-      host: options.host,
-      appId: options.appId,
-      appParams,
-      onReady: options.onReady,
+      ...options,
+      appParams: {
+        widget: options.widget,
+        ...options.appParams,
+      },
     });
 
     if (options.target) {

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -1,24 +1,83 @@
-import { CoinbasePixel, PIXEL_ID } from './CoinbasePixel';
+import { CoinbasePixel, PIXEL_ID, CoinbasePixelConstructorParams } from './CoinbasePixel';
+
+import { onBroadcastedPostMessage } from './postMessage';
+
+jest.mock('./postMessage', () => ({
+  onBroadcastedPostMessage: jest.fn(),
+  broadcastPostMessage: jest.fn(),
+}));
 
 describe('CoinbasePixel', () => {
-  it('creating CoinbasePixel instance should embed a pixel in document', () => {
-    new CoinbasePixel(DEFAULT_ARGS);
+  let mockOnReady: jest.Mock;
+  let defaultArgs: CoinbasePixelConstructorParams;
 
+  beforeEach(() => {
+    mockOnReady = jest.fn();
+    (onBroadcastedPostMessage as jest.Mock).mockReturnValue(jest.fn());
+    defaultArgs = {
+      appId: 'test',
+      appParams: {
+        parameter: 'mock-app-params',
+      },
+      onReady: mockOnReady,
+    };
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should initialize with default values', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    expect(instance.appId).toEqual('test');
+    expect(instance.host).toEqual('https://pay.coinbase.com');
+    expect(instance.pixelIframe).toEqual(expect.any(HTMLIFrameElement));
+    expect(instance.nonce).toEqual('');
+    expect(instance.onReadyCallback).toEqual(mockOnReady);
+    expect(instance.unsubs.length).toEqual(3);
+    expect(instance.appParams).toEqual(defaultArgs.appParams);
+    expect(instance.isReady).toEqual(false);
+    expect(instance.isLoggedIn).toEqual(false);
+  });
+
+  it('should setup default listeners', () => {
+    createUntypedPixel(defaultArgs);
+
+    expect(onBroadcastedPostMessage).toHaveBeenCalledTimes(3);
+    expect(onBroadcastedPostMessage).toHaveBeenCalledWith('pixel_ready', {
+      allowedOrigin: 'https://pay.coinbase.com',
+      onMessage: expect.any(Function),
+      shouldUnsubscribe: false,
+    });
+    expect(onBroadcastedPostMessage).toHaveBeenCalledWith('on_app_params_nonce', {
+      allowedOrigin: 'https://pay.coinbase.com',
+      onMessage: expect.any(Function),
+      shouldUnsubscribe: false,
+    });
+    expect(onBroadcastedPostMessage).toHaveBeenCalledWith('on_app_params_nonce', {
+      allowedOrigin: 'https://pay.coinbase.com',
+      onMessage: expect.any(Function),
+      shouldUnsubscribe: true,
+    });
+  });
+
+  it('should embed the pixel in document', () => {
+    createUntypedPixel(defaultArgs);
     expect(document.querySelector(`iframe#${PIXEL_ID}`)).toBeTruthy();
   });
 
   it('.destroy should remove embedded pixel', () => {
-    const pixel = new CoinbasePixel(DEFAULT_ARGS);
+    const pixel = new CoinbasePixel(defaultArgs);
     expect(document.querySelector(`iframe#${PIXEL_ID}`)).toBeTruthy();
 
     pixel.destroy();
     expect(document.querySelector(`iframe#${PIXEL_ID}`)).toBeNull();
   });
-
-  // TODO: Plenty of more tests we _should_ add here (regarding events/messaging/etc)
 });
 
-const DEFAULT_ARGS: ConstructorParameters<typeof CoinbasePixel>[0] = {
-  appId: 'abc123',
-  appParams: {},
-};
+// Used to assert private properties without type errors
+function createUntypedPixel(options: CoinbasePixelConstructorParams) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new CoinbasePixel(options) as any;
+}

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -38,6 +38,8 @@ describe('CoinbasePixel', () => {
   });
 
   afterEach(() => {
+    document.getElementById(PIXEL_ID)?.remove();
+    document.getElementById(EMBEDDED_IFRAME_ID)?.remove();
     jest.resetAllMocks();
   });
 
@@ -120,9 +122,44 @@ describe('CoinbasePixel', () => {
     expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeTruthy();
   });
 
-  it.todo('should handle openExperience when pixel has status "loading"');
-  it.todo('should handle openExperience when pixel has status "waiting_for_response"');
-  it.todo('should handle openExperience when pixel has status "failed"');
+  it('should handle openExperience when pixel has status "loading"', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    expect(instance.state).toEqual('loading');
+    instance.openExperience(defaultOpenOptions);
+
+    expect(instance.queuedOpenOptions).toBeTruthy();
+    expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeFalsy();
+  });
+
+  it('should handle openExperience when pixel has status "waiting_for_response"', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    instance.state = 'waiting_for_response';
+    instance.openExperience(defaultOpenOptions);
+
+    expect(instance.queuedOpenOptions).toBeFalsy();
+    expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeFalsy();
+  });
+
+  it('should handle openExperience when pixel has status "failed"', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    instance.state = 'failed';
+    instance.openExperience(defaultOpenOptions);
+
+    expect(instance.queuedOpenOptions).toBeFalsy();
+    expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeFalsy();
+  });
+
+  it.todo('should handle openExperience with no preloaded nonce');
+  it.todo('should handle queued open options');
+  it.todo('should handle opening the embedded experience when logged in');
+  it.todo('should handle opening the embedded experience when logged out');
+  it.todo('should handle opening the popup experience in chrome extensions');
+  it.todo('should handle opening the popup experience in browsers');
+  it.todo('should handle opening the new_tab experience in chrome extensions');
+  it.todo('should handle opening the new_tab experience in browsers');
 
   it('should handle max timeout for ready status', () => {
     jest.useFakeTimers();

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -1,6 +1,6 @@
 import { CoinbasePixel, PIXEL_ID, CoinbasePixelConstructorParams } from './CoinbasePixel';
 
-import { onBroadcastedPostMessage } from './postMessage';
+import { broadcastPostMessage, onBroadcastedPostMessage } from './postMessage';
 
 jest.mock('./postMessage', () => ({
   onBroadcastedPostMessage: jest.fn(),
@@ -10,15 +10,16 @@ jest.mock('./postMessage', () => ({
 describe('CoinbasePixel', () => {
   let mockOnReady: jest.Mock;
   let defaultArgs: CoinbasePixelConstructorParams;
+  const defaultAppParams = {
+    parameter: 'mock-app-params',
+  };
 
   beforeEach(() => {
     mockOnReady = jest.fn();
     (onBroadcastedPostMessage as jest.Mock).mockReturnValue(jest.fn());
     defaultArgs = {
       appId: 'test',
-      appParams: {
-        parameter: 'mock-app-params',
-      },
+      appParams: defaultAppParams,
       onReady: mockOnReady,
     };
   });
@@ -35,7 +36,7 @@ describe('CoinbasePixel', () => {
     expect(instance.pixelIframe).toEqual(expect.any(HTMLIFrameElement));
     expect(instance.nonce).toEqual('');
     expect(instance.onReadyCallback).toEqual(mockOnReady);
-    expect(instance.unsubs.length).toEqual(3);
+    expect(instance.unsubs.length).toEqual(2);
     expect(instance.appParams).toEqual(defaultArgs.appParams);
     expect(instance.isReady).toEqual(false);
     expect(instance.isLoggedIn).toEqual(false);
@@ -44,7 +45,7 @@ describe('CoinbasePixel', () => {
   it('should setup default listeners', () => {
     createUntypedPixel(defaultArgs);
 
-    expect(onBroadcastedPostMessage).toHaveBeenCalledTimes(3);
+    expect(onBroadcastedPostMessage).toHaveBeenCalledTimes(2);
     expect(onBroadcastedPostMessage).toHaveBeenCalledWith('pixel_ready', {
       allowedOrigin: 'https://pay.coinbase.com',
       onMessage: expect.any(Function),
@@ -54,11 +55,6 @@ describe('CoinbasePixel', () => {
       allowedOrigin: 'https://pay.coinbase.com',
       onMessage: expect.any(Function),
       shouldUnsubscribe: false,
-    });
-    expect(onBroadcastedPostMessage).toHaveBeenCalledWith('on_app_params_nonce', {
-      allowedOrigin: 'https://pay.coinbase.com',
-      onMessage: expect.any(Function),
-      shouldUnsubscribe: true,
     });
   });
 
@@ -74,10 +70,59 @@ describe('CoinbasePixel', () => {
     pixel.destroy();
     expect(document.querySelector(`iframe#${PIXEL_ID}`)).toBeNull();
   });
+
+  it('should handle pixel_ready message', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    mockPixelReady();
+
+    expect(broadcastPostMessage).toHaveBeenCalledWith(expect.any(Object), 'app_params', {
+      data: defaultAppParams,
+    });
+
+    // 2 listeners now for nonce callback
+    expect(
+      (onBroadcastedPostMessage as jest.Mock).mock.calls.filter(
+        ([message]) => message === 'on_app_params_nonce',
+      ).length,
+    ).toEqual(2);
+
+    expect(instance.isLoggedIn).toEqual(true);
+  });
+
+  it('should handle on_app_params_nonce', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    mockPixelReady();
+    mockOnAppParamsNonce('mock-nonce');
+
+    expect(instance.nonce).toEqual('mock-nonce');
+    expect(instance.isReady).toEqual(true);
+    expect(mockOnReady).toHaveBeenCalledWith();
+  });
+
+  it.todo('should unsubscribe from messages');
 });
 
 // Used to assert private properties without type errors
 function createUntypedPixel(options: CoinbasePixelConstructorParams) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return new CoinbasePixel(options) as any;
+}
+
+function mockPixelReady() {
+  const onMessageCall = (onBroadcastedPostMessage as jest.Mock).mock.calls.find(
+    ([message]) => message === 'pixel_ready',
+  );
+  expect(onMessageCall).toBeTruthy();
+  onMessageCall[1].onMessage({ isLoggedIn: true });
+}
+
+function mockOnAppParamsNonce(nonce: string) {
+  const onMessageCalls = (onBroadcastedPostMessage as jest.Mock).mock.calls.filter(
+    ([message]) => message === 'on_app_params_nonce',
+  );
+  onMessageCalls.forEach((call) => {
+    call[1].onMessage({ nonce });
+  });
 }

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -1,4 +1,5 @@
 import { CoinbasePixel, PIXEL_ID, CoinbasePixelConstructorParams } from './CoinbasePixel';
+import { EMBEDDED_IFRAME_ID } from './createEmbeddedContent';
 
 import { broadcastPostMessage, onBroadcastedPostMessage } from './postMessage';
 
@@ -88,6 +89,8 @@ describe('CoinbasePixel', () => {
     ).toEqual(2);
 
     expect(instance.isLoggedIn).toEqual(true);
+    expect(instance.isReady).toEqual(true);
+    expect(mockOnReady).toHaveBeenCalledWith();
   });
 
   it('should handle on_app_params_nonce', () => {
@@ -97,9 +100,23 @@ describe('CoinbasePixel', () => {
     mockOnAppParamsNonce('mock-nonce');
 
     expect(instance.nonce).toEqual('mock-nonce');
-    expect(instance.isReady).toEqual(true);
-    expect(mockOnReady).toHaveBeenCalledWith();
   });
+
+  it('should handle openExperience when pixel is ready', () => {
+    const pixel = new CoinbasePixel(defaultArgs);
+
+    mockPixelReady();
+    mockOnAppParamsNonce('mock-nonce');
+
+    pixel.openExperience({
+      path: '/buy',
+      experienceLoggedIn: 'embedded',
+    });
+
+    expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeTruthy();
+  });
+
+  it.todo('should handle openExperience when pixel is not ready');
 
   it.todo('should unsubscribe from messages');
 });

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -14,6 +14,8 @@ jest.mock('./postMessage', () => ({
 }));
 
 describe('CoinbasePixel', () => {
+  window.open = jest.fn();
+
   let mockOnReady: jest.Mock;
   let mockOnFallbackOpen: jest.Mock;
   let defaultArgs: CoinbasePixelConstructorParams;
@@ -152,7 +154,19 @@ describe('CoinbasePixel', () => {
     expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeFalsy();
   });
 
-  it.todo('should handle openExperience with no preloaded nonce');
+  it('should handle openExperience with no preloaded nonce', () => {
+    const instance = createUntypedPixel(defaultArgs);
+
+    instance.state = 'ready';
+    instance.isLoggedIn = true;
+    instance.openExperience(defaultOpenOptions);
+
+    expect(instance.state).toEqual('waiting_for_response');
+    mockOnAppParamsNonce('mock-nonce');
+
+    expect(document.querySelector(`iframe#${EMBEDDED_IFRAME_ID}`)).toBeTruthy();
+  });
+
   it.todo('should handle queued open options');
   it.todo('should handle opening the embedded experience when logged in');
   it.todo('should handle opening the embedded experience when logged out');

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -25,7 +25,7 @@ export type ExperienceListeners = {
   onEvent?: (event: EventMetadata) => void;
 };
 
-type CoinbasePixelConstructorParams = {
+export type CoinbasePixelConstructorParams = {
   host?: string;
   appId: string;
   appParams: JsonObject;
@@ -101,7 +101,7 @@ export class CoinbasePixel {
         const openEmbeddedExperience = () => {
           const embedded = createEmbeddedContent({ url, ...embeddedContentStyles });
           if (embeddedContentStyles?.target) {
-            document.querySelector(embeddedContentStyles?.target)?.appendChild(embedded);
+            document.querySelector(embeddedContentStyles?.target)?.replaceChildren(embedded);
           } else {
             document.body.appendChild(embedded);
           }

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -98,7 +98,7 @@ export class CoinbasePixel {
 
   /** Opens the CB Pay experience */
   public openExperience = (options: OpenExperienceOptions): void => {
-    this.log('Attempting to open experience', `state:${this.state}`);
+    this.log('Attempting to open experience', { state: this.state });
 
     // Avoid double clicking when we are waiting on a response for a new nonce
     if (this.state === 'waiting_for_response') {
@@ -130,7 +130,7 @@ export class CoinbasePixel {
         ? experienceLoggedIn
         : experienceLoggedOut || experienceLoggedIn;
 
-      this.log('Opening experience', `[experience:${experience}]`);
+      this.log('Opening experience', { experience, isLoggedIn: this.isLoggedIn });
       widgetUrl.searchParams.append('nonce', nonce);
       const url = widgetUrl.toString();
 
@@ -213,6 +213,7 @@ export class CoinbasePixel {
     });
   };
 
+  /** Creates and adds the pixel to the document */
   private embedPixel = (): void => {
     document.getElementById(PIXEL_ID)?.remove();
     const pixel = createPixel({
@@ -220,7 +221,6 @@ export class CoinbasePixel {
       appId: this.appId,
     });
 
-    // Pixel failed to load in general
     pixel.onerror = this.onFailedToLoad;
 
     this.pixelIframe = pixel;

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -190,6 +190,7 @@ export class CoinbasePixel {
 
   public destroy = (): void => {
     document.getElementById(PIXEL_ID)?.remove();
+    this.queuedOpenOptions = undefined;
     this.unsubs.forEach((unsub) => unsub());
   };
 

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -159,18 +159,10 @@ export class CoinbasePixel {
     this.onMessage('pixel_ready', {
       shouldUnsubscribe: false,
       onMessage: (data) => {
-        this.isLoggedIn = !!data?.isLoggedIn as boolean;
-        this.sendAppParams(this.appParams);
-      },
-    });
-
-    // First time only. Pixel is considered ready when we've setup the
-    // app params for the first time - this avoids race conditions with nonces when opening.
-    this.onMessage('on_app_params_nonce', {
-      shouldUnsubscribe: true,
-      onMessage: () => {
         this.isReady = true;
+        this.isLoggedIn = !!data?.isLoggedIn as boolean;
         this.onReadyCallback?.();
+        this.sendAppParams(this.appParams);
       },
     });
 

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -130,9 +130,10 @@ export class CoinbasePixel {
         ? experienceLoggedIn
         : experienceLoggedOut || experienceLoggedIn;
 
-      this.log('Opening experience', { experience, isLoggedIn: this.isLoggedIn });
       widgetUrl.searchParams.append('nonce', nonce);
       const url = widgetUrl.toString();
+
+      this.log('Opening experience', { experience, isLoggedIn: this.isLoggedIn });
 
       if (experience === 'embedded') {
         const openEmbeddedExperience = () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/utils/postMessage.ts'],
+  entry: ['src/index.ts', 'src/utils/postMessage.ts', 'src/utils/CBPayInstance.ts'],
   splitting: true,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
Implements https://github.com/coinbase/cbpay-js/pull/34

### Description
- Implement fallback functionality when we fail to load the pixel or receive app parameters in a max timeout period (fixes Firefox and Safari)
- Add debug option to allow for inspecting the initialization process
- Add a pixel state property to better track the state of the pixel when attempting to open the experience.
  - Avoid race conditions when waiting for an app params response.
  - Queue open options when we're loading.
- Add a bunch of tests around the whole initialization flow.

### Testing
- [x] Embedded experience (logged out then open)
- [x] Embedded experience (logged in)
- [x] Popup
- [x] New tab