### PR TITLE
Handle init error events / better callback typing

### DIFF
--- a/src/onramp/initOnRamp.ts
+++ b/src/onramp/initOnRamp.ts
@@ -5,7 +5,10 @@ import { generateOnRampURL } from './generateOnRampURL';
 
 export type InitOnRampParams = CBPayExperienceOptions<OnRampAppParams>;
 
-export type InitOnRampCallback = (error: Error | undefined, instance: CBPayInstanceType) => void;
+export type InitOnRampCallback = {
+  (error: Error, instance: null): void;
+  (error: null, instance: CBPayInstanceType): void;
+};
 
 export const initOnRamp = (
   {
@@ -21,7 +24,11 @@ export const initOnRamp = (
     experienceLoggedIn,
     appParams: widgetParameters,
     onReady: (error) => {
-      callback(error, instance);
+      if (error) {
+        callback(error, null);
+      } else {
+        callback(null, instance);
+      }
     },
     onFallbackOpen: () => {
       const url = generateOnRampURL({

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -85,6 +85,7 @@ export class CoinbasePixel {
     this.debug = debug || false;
 
     this.addPixelReadyListener();
+    this.addErrorListener();
     this.embedPixel();
 
     // Setup a timeout for errors that might stop the window from loading i.e. CSP
@@ -216,6 +217,20 @@ export class CoinbasePixel {
         this.sendAppParams(() => {
           this.onReadyCallback?.();
         });
+      },
+    });
+  };
+
+  private addErrorListener = (): void => {
+    // TODO - remove this after successful initialization.
+    this.onMessage('error', {
+      shouldUnsubscribe: true, // We only want the user-provided callback to be called once.
+      onMessage: (data) => {
+        this.log('Received message: error');
+
+        if (data) {
+          this.onReadyCallback?.(new Error(JSON.stringify(data)));
+        }
       },
     });
   };

--- a/src/utils/postMessage.ts
+++ b/src/utils/postMessage.ts
@@ -8,6 +8,7 @@ export enum MessageCodes {
   Success = 'success', // TODO: deprecate
   Exit = 'exit', // TODO: deprecate
   Event = 'event',
+  Error = 'error',
 
   PixelReady = 'pixel_ready',
   OnAppParamsNonce = 'on_app_params_nonce',


### PR DESCRIPTION
### Description & motivation
<!--
Simple summary of what the code does or what you have changed.
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
This PR adds the following:
* Better typing for the init callback function. As is done in the Node-style callbacks, any empty values are now explicitly set to `null`. The callback function now has 2 type overloads to better express this scenario. This will allow consumers to explicitly check for an error or an instance and handle their UI accordingly.
* The `CoinbasePixel` instance now has a new private `addErrorListener` method. This allows the pixel to provide the consumers callback function with errors from a variety of sources, such as a failure to parse app params.

<!-- (optional) Uncomment below if this is linked to an issue or another pull request -->
<!-- Fixes # -->

### Testing & documentation

Added unit tests to cover the changes.

<!-- How did you test this change? i.e. "Unit tests". -->

<!-- If this made updates to parameters, have you updated the documentation? -->


<!-- Optional sections -->

<!--
### Open questions
(optional) Any open questions or feedback on design desired?
-->
