### PR TITLE
Better usage of `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,22 +6,18 @@
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
-    ".": [
-      {
-        "import": "./dist/index.mjs",
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "./dist/index.js"
-    ],
-    "./internal": [
-      {
-        "import": "./dist/internal.mjs",
-        "types": "./dist/internal.d.ts",
-        "default": "./dist/internal.js"
-      },
-      "./dist/internal.js"
-    ],
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./internal": {
+      "types": "./dist/internal.d.ts",
+      "import": "./dist/internal.mjs",
+      "require": "./dist/internal.js",
+      "default": "./dist/internal.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,9 @@ export default defineConfig({
   splitting: true,
   sourcemap: true,
   clean: true,
-  dts: true,
+  dts: {
+    resolve: true,
+  },
   format: ['cjs', 'esm'],
   target: 'es5',
 });


### PR DESCRIPTION
### Description & motivation
<!--
Simple summary of what the code does or what you have changed.
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Adjusting the exports field to what's recommended in the [Node docs](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#exports):
* `types` should always [come first](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#community-conditions-definitions).
* [Order matters](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#conditional-exports), so `import` comes after types.
* Added a `require` field since we export a build for that as well.
* Each [subpath export](https://nodejs.org/dist/latest-v18.x/docs/api/packages.html#subpath-exports) should be an object, not an array.

<!-- (optional) Uncomment below if this is linked to an issue or another pull request -->
<!-- Fixes # -->

### Testing & documentation

<!-- How did you test this change? i.e. "Unit tests". -->

<!-- If this made updates to parameters, have you updated the documentation? -->


<!-- Optional sections -->

<!--
### Open questions
(optional) Any open questions or feedback on design desired?
-->
