### PR TITLE
Add optional failedToLoad reason

### DIFF
--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -302,7 +302,9 @@ describe('CoinbasePixel', () => {
     jest.advanceTimersToNextTimer();
 
     expect(instance.state).toEqual('failed');
-    expect(mockOnReady).toHaveBeenCalledWith(new Error('Failed to load CB Pay pixel'));
+    expect(mockOnReady).toHaveBeenCalledWith(
+      new Error('Failed to load CB Pay pixel with reason: timeout'),
+    );
 
     jest.useRealTimers();
     console.warn = originalWarn;

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -93,7 +93,7 @@ export class CoinbasePixel {
     // Setup a timeout for errors that might stop the window from loading i.e. CSP
     setTimeout(() => {
       if (this.state !== 'ready') {
-        this.onFailedToLoad();
+        this.onFailedToLoad('timeout');
       }
     }, DEFAULT_MAX_LOAD_TIMEOUT);
   }
@@ -246,14 +246,14 @@ export class CoinbasePixel {
       appId: this.appId,
     });
 
-    pixel.onerror = this.onFailedToLoad;
+    pixel.onerror = () => this.onFailedToLoad;
 
     this.pixelIframe = pixel;
     document.body.appendChild(pixel);
   };
 
   /** Failed to load the pixel iframe */
-  private onFailedToLoad = () => {
+  private onFailedToLoad = (reason?: string) => {
     this.state = 'failed';
 
     // If a fallback option is provided we only want to provide a warning since we can still attempt to open the widget
@@ -263,7 +263,12 @@ export class CoinbasePixel {
       }
       this.onReadyCallback?.();
     } else {
-      const error = new Error('Failed to load CB Pay pixel');
+      let message = 'Failed to load CB Pay pixel';
+      if (reason) {
+        message += ` with reason: ${reason}`;
+      }
+
+      const error = new Error(message);
       if (this.debug) {
         console.error(error);
       }


### PR DESCRIPTION
### Description & motivation
<!--
Simple summary of what the code does or what you have changed.
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Adds an optional reason to the pixel's `failedToLoad` method which allows for logging a reason for load failure.

<!-- (optional) Uncomment below if this is linked to an issue or another pull request -->
<!-- Fixes # -->

### Testing & documentation

<!-- How did you test this change? i.e. "Unit tests". -->

<!-- If this made updates to parameters, have you updated the documentation? -->


<!-- Optional sections -->

<!--
### Open questions
(optional) Any open questions or feedback on design desired?
-->
