### PR TITLE
[Secure initialization] Add `onrampToken` to `generateOnRampURL`

### DIFF
--- a/src/onramp/generateOnRampURL.test.ts
+++ b/src/onramp/generateOnRampURL.test.ts
@@ -15,6 +15,17 @@ describe('generateOnrampURL', () => {
     expect(url.searchParams.get('appId')).toEqual('test');
   });
 
+  it('should support onrampToken', () => {
+    const url = new URL(
+      generateOnRampURL({
+        onrampToken: 'test',
+      }),
+    );
+    expect(url.origin).toEqual('https://pay.coinbase.com');
+    expect(url.pathname).toEqual('/buy/select-asset');
+    expect(url.searchParams.get('onrampToken')).toEqual('test');
+  });
+
   it('generates URL with empty destination wallets', () => {
     const url = new URL(
       generateOnRampURL({

--- a/src/onramp/generateOnRampURL.ts
+++ b/src/onramp/generateOnRampURL.ts
@@ -21,7 +21,6 @@ export const generateOnRampURL = ({
   if (destinationWallets !== undefined) {
     url.searchParams.append('destinationWallets', JSON.stringify(destinationWallets));
   }
-  
   (Object.keys(otherParams) as (keyof typeof otherParams)[]).forEach((key) => {
     const value = otherParams[key];
     if (value !== undefined) {

--- a/src/onramp/generateOnRampURL.ts
+++ b/src/onramp/generateOnRampURL.ts
@@ -2,9 +2,13 @@ import { DEFAULT_HOST } from '../config';
 import { OnRampAppParams } from '../types/onramp';
 
 export type GenerateOnRampURLOptions = {
-  appId: string;
+  /** This & destinationWallets or onrampToken are required. */
+  appId?: string;
+  destinationWallets?: OnRampAppParams['destinationWallets'];
   host?: string;
-} & OnRampAppParams;
+  /** This or appId & destinationWallets are required. */
+  onrampToken?: string;
+} & Omit<OnRampAppParams, 'destinationWallets'>;
 
 export const generateOnRampURL = ({
   host = DEFAULT_HOST,
@@ -14,8 +18,10 @@ export const generateOnRampURL = ({
   const url = new URL(host);
   url.pathname = '/buy/select-asset';
 
-  url.searchParams.append('destinationWallets', JSON.stringify(destinationWallets));
-
+  if (destinationWallets !== undefined) {
+    url.searchParams.append('destinationWallets', JSON.stringify(destinationWallets));
+  }
+  
   (Object.keys(otherParams) as (keyof typeof otherParams)[]).forEach((key) => {
     const value = otherParams[key];
     if (value !== undefined) {


### PR DESCRIPTION
### Description & motivation
<!--
Simple summary of what the code does or what you have changed.
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
Adding `onrampToken` parameter to `generateOnRampURL` to allow for secure initialization.

<!-- (optional) Uncomment below if this is linked to an issue or another pull request -->
<!-- Fixes # -->

### Testing & documentation

<!-- How did you test this change? i.e. "Unit tests". -->
Added unit test.

<!-- If this made updates to parameters, have you updated the documentation? -->


<!-- Optional sections -->

<!--
### Open questions
(optional) Any open questions or feedback on design desired?
-->
