### PR TITLE
Add permissions to npm-publish action to enable provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,9 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### Description & motivation
<!--
Simple summary of what the code does or what you have changed.
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Our new NPM publish workflow failed because of some missing permissions:
https://github.com/coinbase/cbpay-js/actions/runs/9489681461/job/26151544199

The fix for this is documented here - https://docs.npmjs.com/generating-provenance-statements

<!-- (optional) Uncomment below if this is linked to an issue or another pull request -->
<!-- Fixes # -->

### Testing & documentation

<!-- How did you test this change? i.e. "Unit tests". -->

<!-- If this made updates to parameters, have you updated the documentation? -->


<!-- Optional sections -->

<!--
### Open questions
(optional) Any open questions or feedback on design desired?
-->
