### PR TITLE
Add sessionToken parameter support to initOnRamp

### DIFF
--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -20,10 +20,19 @@ export type EmbeddedContentStyles = {
   top?: string;
 };
 
-export type CBPayExperienceOptions<T> = {
+export type CBPayExperienceWithAppId<T> = {
+  appId: string;
+  sessionToken?: never;
+} & CBPayExperienceBaseOptions<T>;
+
+export type CBPayExperienceWithSessionToken<T> = {
+  sessionToken: string;
+  appId?: never;
+} & CBPayExperienceBaseOptions<T>;
+
+type CBPayExperienceBaseOptions<T> = {
   widgetParameters: T;
   target?: string;
-  appId: string;
   host?: string;
   debug?: boolean;
   theme?: Theme;
@@ -37,3 +46,7 @@ export type CBPayExperienceOptions<T> = {
   experienceLoggedIn?: Experience;
   experienceLoggedOut?: Experience;
 };
+
+export type CBPayExperienceOptions<T> =
+  | CBPayExperienceWithAppId<T>
+  | CBPayExperienceWithSessionToken<T>;

--- a/src/utils/CoinbasePixel.test.ts
+++ b/src/utils/CoinbasePixel.test.ts
@@ -50,6 +50,12 @@ describe('CoinbasePixel', () => {
     expect(instance.appParams).toEqual(defaultArgs.appParams);
   });
 
+  it('should initialize with sessionToken', () => {
+    const instance = createUntypedPixel({ sessionToken: 'test', appParams: defaultAppParams });
+
+    expect(instance.sessionToken).toEqual('test');
+  });
+
   it('should handle opening the embedded experience when logged out', () => {
     const instance = createUntypedPixel(defaultArgs);
 

--- a/src/utils/CoinbasePixel.ts
+++ b/src/utils/CoinbasePixel.ts
@@ -26,7 +26,8 @@ export type ExperienceListeners = {
 
 export type CoinbasePixelConstructorParams = {
   host?: string;
-  appId: string;
+  appId?: string;
+  sessionToken?: string;
   appParams: JsonObject;
   debug?: boolean;
   theme?: Theme;
@@ -42,7 +43,8 @@ export type OpenExperienceOptions = {
 export class CoinbasePixel {
   private debug: boolean;
   private host: string;
-  private appId: string;
+  private appId: string | undefined;
+  private sessionToken: string | undefined;
   private eventStreamListeners: Partial<Record<EventMetadata['eventName'], (() => void)[]>> = {};
   private unsubs: (() => void)[] = [];
   private appParams: JsonObject;
@@ -52,12 +54,14 @@ export class CoinbasePixel {
   constructor({
     host = DEFAULT_HOST,
     appId,
+    sessionToken,
     appParams,
     debug,
     theme,
   }: CoinbasePixelConstructorParams) {
     this.host = host;
     this.appId = appId;
+    this.sessionToken = sessionToken;
     this.appParams = appParams;
     this.debug = debug || false;
     this.theme = theme;
@@ -75,6 +79,7 @@ export class CoinbasePixel {
 
     const url = generateOnRampURL({
       appId: this.appId,
+      sessionToken: this.sessionToken,
       host: this.host,
       theme: this.theme ?? undefined,
       ...this.appParams,
@@ -171,6 +176,10 @@ export class CoinbasePixel {
   };
 
   private startDirectSignin = (callback: () => void) => {
+    if (!this.appId) {
+      throw new Error('appId is required for direct signin');
+    }
+
     const queryParams = new URLSearchParams();
     queryParams.set('appId', this.appId);
     queryParams.set('type', 'direct');


### PR DESCRIPTION
### Description & motivation

I propose extending the `initOnRamp` function by introducing support for a `sessionToken` parameter. This would allow users to initialize the function using either `sessionToken` or `appId`.

To ensure this update is fully integrated, I’ve updated the TypeScript types to include `sessionToken` as a valid parameter, maintaining type safety throughout the codebase. Additionally, I’ve written new test case to confirm that the `sessionToken` functionality works as expected and that there are no regressions with the current implementation.

This change would enhance the current functionality without disrupting the existing workflow for those using `appId`.

Do you think this kind of update would fit with the project’s goals and be something worth including?

### Testing & documentation

I've covered adding the `sessionToken` parameter with the unit test.
